### PR TITLE
Add osx-arm64 to make it work on apple m1 mac

### DIFF
--- a/client/fsac.ts
+++ b/client/fsac.ts
@@ -22,6 +22,10 @@ const fsac_pkgs: ILanguageServerPackages = {
         executable: "fsautocomplete.dll",
         platformPath: "fsautocomplete.netcore.zip"
     },
+    "osx-arm64": {
+        executable: "fsautocomplete.dll",
+        platformPath: "fsautocomplete.netcore.zip"
+    },
 }
 
 const fsac_repo: LanguageServerRepository = {


### PR DESCRIPTION
Otherwise, it will fail to start the language server with an error of platform not support.